### PR TITLE
DEVOPS-1917: ruby 3.2 compatibility

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,7 +42,7 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        if File.exists?(config)
+        if File.exist?(config)
           # puts "Configuration: #{config}"
           require config
         end


### PR DESCRIPTION
`exists?` does not, ahem, exist in Ruby 3.2.